### PR TITLE
added v2021.2.2 (build 212.*) to the versions that this plugin runs with

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ pluginVersion = 0.5.0
 ## https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html#intellij-platform-based-products-of-recent-ide-versions
 ## Since 2019.2 (192), until most recent (currently 211 / 2021.1)
 pluginSinceBuild = 192
-pluginUntilBuild = 211.*
+pluginUntilBuild = 212.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
@@ -21,7 +21,7 @@ pluginUntilBuild = 211.*
 #### > Task :runPluginVerifier
 ####     [gradle-intellij-plugin :JavaParser AST Inspector:runPluginVerifier] Cannot resolve direct download URL for: https://data.services.jetbrains.com/products/download?code=IC&platform=linux&type=release&version=2019.3
 ####     java.io.FileNotFoundException: https://data.services.jetbrains.com/products/download?code=IC&platform=linux&type=release&version=2019.3
-pluginVerifierIdeVersions = 2019.3.5, 2020.1.4, 2020.2.4, 2020.3.2, 2021.1
+pluginVerifierIdeVersions = 2019.3.5, 2020.1.4, 2020.2.4, 2020.3.2, 2021.1, 2021.2.2
 
 #// See https://github.com/JetBrains/gradle-intellij-plugin/#intellij-platform-properties
 #// Note that the default is 'LATEST-EAP-SNAPSHOT', but can be set to specific versions (e.g. '2020.1')


### PR DESCRIPTION
closes #132 