### PR TITLE
Changelog update - v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,19 +14,6 @@
 ### Security
 
 ## [0.5.2]
-### Added
-
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
-
-## [0.5.2]
 ### Changed
 - Bumped `pluginUntilBuild` to allow for 2021.3
 - Upgraded to using JavaParser v3.24.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,37 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.5.2]
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.5.2]
 ### Changed
 - Bumped `pluginUntilBuild` to allow for 2021.3
 - Upgraded to using JavaParser v3.24.0
 - Update the project with recent template project changes (workflow tweaks, added qodana, keeping detekt (for now))
 - Multiple other dependency updates
-
 
 ## [0.5.1]
 ### Changed


### PR DESCRIPTION
Should be automatic, but contained a reference to the non-existent `main` branch (fixed in a389869a5c4416e63efcb3ab9a7c9abc6c43d930 ).