### PR TITLE
initial inclusion of a live template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- Now includes a "live template" which inserts the JavaParser boilerplate (type `parseString` then `TAB` within a Java file)
 
 ### Changed
 

--- a/src/main/java/com/github/rogerhowell/javaparser_ast_inspector/plugin/live_templates/JavaParserContext.java
+++ b/src/main/java/com/github/rogerhowell/javaparser_ast_inspector/plugin/live_templates/JavaParserContext.java
@@ -1,0 +1,56 @@
+package com.github.rogerhowell.javaparser_ast_inspector.plugin.live_templates;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ast.CompilationUnit;
+import com.intellij.codeInsight.template.TemplateActionContext;
+import com.intellij.codeInsight.template.TemplateContextType;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiImportStatementBase;
+import com.intellij.psi.PsiJavaCodeReferenceElement;
+import com.intellij.psi.PsiJavaFile;
+import org.jetbrains.annotations.NotNull;
+
+public class JavaParserContext extends TemplateContextType {
+
+    protected JavaParserContext() {
+        super("JAVAPARSER", "JavaParser");
+    }
+
+
+    @Override
+    public boolean isInContext(@NotNull TemplateActionContext templateActionContext) {
+        PsiFile psiFile = templateActionContext.getFile();
+
+        if (!psiFile.getName().endsWith(".java")) {
+            // Only consider Java files
+//            System.err.println("JAVAPARSER (live template context) -- Not a file ending in .java");
+            return false;
+        }
+
+        if (!(psiFile.getContainingFile() instanceof PsiJavaFile)) {
+            // Only consider Java files
+//            System.err.println("JAVAPARSER (live template context) -- Not a PsiJavaFile");
+            return false;
+        }
+
+//        System.out.println("JAVAPARSER (live template context) -- valid context found");
+
+        return true;
+
+//        /* THE FILTERING BELOW WORKS, BUT I'M DISABLING */
+//        PsiJavaFile psiJavaFile = (PsiJavaFile) psiFile;
+//        for (final PsiImportStatementBase importStatement : psiJavaFile.getImportList().getAllImportStatements()) {
+//            PsiJavaCodeReferenceElement importReference = importStatement.getImportReference();
+//
+//            boolean isInJavaParserNamespace = importReference.getQualifiedName().startsWith("com.github.javaparser.");
+//            if (isInJavaParserNamespace) {
+//                return true;
+//            }
+//        }
+//
+//        // If no matches, assume none of them are JavaParser, thus we are not in context.
+//        return false;
+    }
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -33,6 +33,12 @@
                         serviceImplementation="com.github.rogerhowell.javaparser_ast_inspector.plugin.services.impl.JavaParserServiceImpl"/>
         <projectService serviceInterface="com.github.rogerhowell.javaparser_ast_inspector.plugin.services.PrinterService"
                         serviceImplementation="com.github.rogerhowell.javaparser_ast_inspector.plugin.services.impl.PrinterServiceImpl"/>
+
+
+        <!-- Code completion -->
+        <defaultLiveTemplates file="/liveTemplates/JavaParser.xml"/>
+        <liveTemplateContext implementation="com.github.rogerhowell.javaparser_ast_inspector.plugin.live_templates.JavaParserContext"/>
+
     </extensions>
 
     <actions>

--- a/src/main/resources/liveTemplates/JavaParser.xml
+++ b/src/main/resources/liveTemplates/JavaParser.xml
@@ -1,0 +1,16 @@
+<templateSet group="Java/JavaParser">
+    <template name="parseString"
+              value="java.lang.String inputToParse = &quot;$INPUT_TO_BE_PARSED$&quot;;&#10;com.github.javaparser.JavaParser javaParser = new com.github.javaparser.JavaParser();&#10;com.github.javaparser.ParseResult&lt;$NODE_TYPE$&gt; parseResult = javaParser.$PARSE_METHOD$(inputToParse);&#10;if (parseResult.isSuccessful()) {&#10;    if (parseResult.getResult().isPresent()) {&#10;        $NODE_TYPE$ $NODE_TYPE_VAR_NAME$ = parseResult.getResult().get();&#10;        // Do things with the compilation unit&#10;        $END$&#10;    } else {&#10;        System.out.println(&quot;Warning: Parsing was successful, but no $NODE_TYPE$ found. &quot;);&#10;    }&#10;} else {&#10;    System.out.println(&quot;Warning: Parse was unsuccessful. Attempts to inspect/alter the AST may be possible, but may lead to unintended outputs.&quot;);&#10;    if (parseResult.getResult().isPresent()) {&#10;        $NODE_TYPE$ $NODE_TYPE_VAR_NAME$WithParseError = parseResult.getResult().get();&#10;        // Do things with the compilation unit (with parse error)&#10;        &#10;    } else {&#10;        System.out.println(&quot;Warning: Parsing was successful, but no $NODE_TYPE$ found. &quot;);&#10;    }&#10;}"
+              description="Setup JavaParser to parse raw String input"
+              toReformat="true"
+              toShortenFQNames="true">
+        <variable name="INPUT_TO_BE_PARSED" expression="" defaultValue="&quot;class X {}&quot;" alwaysStopAt="true" />
+        <variable name="NODE_TYPE" expression="subTypes(&quot;com.github.javaparser.ast.Node&quot;)" defaultValue="&quot;com.github.javaparser.ast.CompilationUnit&quot;" alwaysStopAt="true" />
+        <variable name="PARSE_METHOD" expression="completeSmart()" defaultValue="&quot;parse&quot;" alwaysStopAt="true" />
+        <variable name="NODE_TYPE_VAR_NAME" expression="suggestVariableName()" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="JAVA_CODE" value="true" />
+            <option name="JAVAPARSER" value="true" />
+        </context>
+    </template>
+</templateSet>


### PR DESCRIPTION

This "live template" creates a complete boilerplate for parsing and handling `String` parse input. 

- While I'm not 100% on the actual content of the template and it can probably be improved _(suggestions/issues/pull requests welcome!)_, it's a start showing it can be done! :+1: :grin: 

- As an aside, it highlights how much the `StaticJavaParser` hides from you and the logic paths/branches that are not handled/able to be handled if using it...

Here is a sample of the output (note it will auto-format based on your editor settings):

```java
        String inputToParse = "class X {}";
        JavaParser javaParser = new JavaParser();
        ParseResult<CompilationUnit> parseResult = javaParser.parse(inputToParse);
        if (parseResult.isSuccessful()) {
            if (parseResult.getResult().isPresent()) {
                CompilationUnit compilationUnit = parseResult.getResult().get();
                // Do things with the compilation unit

            } else {
                System.out.println("Warning: Parsing was successful, but no CompilationUnit found. ");
            }
        } else {
            System.out.println("Warning: Parse was unsuccessful. Attempts to inspect/alter the AST may be possible, but may lead to unintended outputs.");
            if (parseResult.getResult().isPresent()) {
                CompilationUnit compilationUnitWithParseError = parseResult.getResult().get();
                // Do things with the compilation unit (with parse error)

            } else {
                System.out.println("Warning: Parsing was successful, but no CompilationUnit found. ");
            }
        }
```

---

## Here's a screenshot showing the places where input is prompted for. 

![image](https://user-images.githubusercontent.com/1537214/150694155-4af2a303-3347-4b28-a3b1-e221178cff99.png)

---

## Here's a screenshot showing how it reacts to parsing an `Expression` instead of a full `CompilationUnit`. 

Note the auto-suggested variable names update based on the previous selections.

![image](https://user-images.githubusercontent.com/1537214/150694187-3e7bfffc-e0ab-4b13-a9b9-de4ca68d91e2.png)

---

## Here's a screenshot showing how it reacts to using a different variable name

Note here that I manually tweak it to `expr` instead of `expression`, and further down the variable has updated to `exprWithParseError`.

![image](https://user-images.githubusercontent.com/1537214/150694288-021431c8-1fb7-493d-a67e-e4cc2f401a79.png)
