### PR TITLE
Remove hardcoded plugin verification versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,9 @@ pluginUntilBuild = 213.*
 #### > Task :runPluginVerifier
 ####     [gradle-intellij-plugin :JavaParser AST Inspector:runPluginVerifier] Cannot resolve direct download URL for: https://data.services.jetbrains.com/products/download?code=IC&platform=linux&type=release&version=2019.3
 ####     java.io.FileNotFoundException: https://data.services.jetbrains.com/products/download?code=IC&platform=linux&type=release&version=2019.3
-pluginVerifierIdeVersions = 2019.3.5, 2020.1.4, 2020.2.4, 2020.3.2, 2021.1, 2021.3, 2021.3.1, 2021.3.2
+#pluginVerifierIdeVersions = 2019.3.5, 2020.1.4, 2020.2.4, 2020.3.2, 2021.1, 2021.3, 2021.3.1, 2021.3.2
+## Leaving this blank will automatically determine the versions to check against
+pluginVerifierIdeVersions =
 
 #// See https://github.com/JetBrains/gradle-intellij-plugin/#intellij-platform-properties
 #// Note that the default is 'LATEST-EAP-SNAPSHOT', but can be set to specific versions (e.g. '2020.1')


### PR DESCRIPTION
leaving it blank will automatically determine the versions to check against